### PR TITLE
Convert preview-frame.js to TypeScript

### DIFF
--- a/css/preview-frame.css
+++ b/css/preview-frame.css
@@ -1,0 +1,14 @@
+html, body {
+  height: 100%;
+}
+
+body {
+  margin: 0;
+  display: flex;
+
+  /* This centers our sketch horizontally. */
+  justify-content: center;
+
+  /* This centers our sketch vertically. */
+  align-items: center;
+}

--- a/lib/preview-frame.ts
+++ b/lib/preview-frame.ts
@@ -1,5 +1,10 @@
 require("../css/preview-frame.css");
 
+declare interface PreviewFrameWindow extends PreviewFrame {
+  // This is exported by p5 when it's in global mode.
+  noLoop: () => void;
+}
+
 var global = window as PreviewFrameWindow;
 
 function loadP5(version: string, cb?: () => void) {

--- a/lib/preview-frame.ts
+++ b/lib/preview-frame.ts
@@ -1,6 +1,6 @@
 require("../css/preview-frame.css");
 
-var global = window as any;
+var global = window as PreviewFrameWindow;
 
 function loadP5(version: string, cb?: () => void) {
   var url = '//cdnjs.cloudflare.com/ajax/libs/p5.js/' + version + '/p5.js';
@@ -14,7 +14,7 @@ function loadP5(version: string, cb?: () => void) {
   document.body.appendChild(script);
 }
 
-function LoopChecker(sketch, funcName, maxRunTime) {
+function LoopChecker(sketch: string, funcName: string, maxRunTime: number) {
   var self = {
     wasTriggered: false,
     getLineNumber() {
@@ -47,14 +47,15 @@ function LoopChecker(sketch, funcName, maxRunTime) {
   return self;
 }
 
-function startSketch(sketch, p5version, maxRunTime, loopCheckFuncName,
-                     errorCb) {
+function startSketch(sketch: string, p5version: string, maxRunTime: number,
+                     loopCheckFuncName: string,
+                     errorCb: PreviewFrameErrorReporter) {
   var sketchScript = document.createElement('script');
   var loopChecker = LoopChecker(sketch, loopCheckFuncName, maxRunTime);
 
   sketchScript.textContent = sketch;
 
-  global.addEventListener('error', function(e) {
+  global.addEventListener('error', function(e: ErrorEvent) {
     var message = e.message;
     var line = undefined;
 

--- a/lib/preview-frame.ts
+++ b/lib/preview-frame.ts
@@ -1,6 +1,6 @@
 require("../css/preview-frame.css");
 
-declare interface PreviewFrameWindow extends PreviewFrame {
+interface PreviewFrameWindow extends PreviewFrame {
   // This is exported by p5 when it's in global mode.
   noLoop: () => void;
 }

--- a/lib/preview-frame.ts
+++ b/lib/preview-frame.ts
@@ -1,3 +1,5 @@
+require("../css/preview-frame.css");
+
 var global = window as any;
 
 function loadP5(version: string, cb?: () => void) {

--- a/lib/preview-frame.ts
+++ b/lib/preview-frame.ts
@@ -1,4 +1,6 @@
-function loadP5(version, cb) {
+var global = window as any;
+
+function loadP5(version: string, cb?: () => void) {
   var url = '//cdnjs.cloudflare.com/ajax/libs/p5.js/' + version + '/p5.js';
   var script = document.createElement('script');
 
@@ -7,15 +9,28 @@ function loadP5(version, cb) {
   script.onload = cb;
   script.setAttribute('src', url);
 
-  document.body.appendChild(script);    
+  document.body.appendChild(script);
 }
 
 function LoopChecker(sketch, funcName, maxRunTime) {
-  var self = {};
+  var self = {
+    wasTriggered: false,
+    getLineNumber() {
+      var index = loopCheckFailureRange[0];
+      var line = 1;
+
+      for (var i = 0; i < index; i++) {
+        if (sketch[i] === '\n')
+          line++;
+      }
+
+      return line;
+    }
+  };
   var startTime = Date.now();
   var loopCheckFailureRange = null;
 
-  window[funcName] = function(range) {
+  global[funcName] = function(range) {
     if (Date.now() - startTime > maxRunTime) {
       self.wasTriggered = true;
       loopCheckFailureRange = range;
@@ -23,21 +38,7 @@ function LoopChecker(sketch, funcName, maxRunTime) {
     }
   };
 
-  self.getLineNumber = function() {
-    var index = loopCheckFailureRange[0];
-    var line = 1;
-
-    for (var i = 0; i < index; i++) {
-      if (sketch[i] === '\n')
-        line++;
-    }
-
-    return line;
-  };
-
-  self.wasTriggered = false;
-
-  window.setInterval(function() {
+  setInterval(function() {
     startTime = Date.now();
   }, maxRunTime / 2);
 
@@ -51,7 +52,7 @@ function startSketch(sketch, p5version, maxRunTime, loopCheckFuncName,
 
   sketchScript.textContent = sketch;
 
-  window.addEventListener('error', function(e) {
+  global.addEventListener('error', function(e) {
     var message = e.message;
     var line = undefined;
 
@@ -65,7 +66,7 @@ function startSketch(sketch, p5version, maxRunTime, loopCheckFuncName,
 
     // p5 sketches don't actually stop looping if they throw an exception,
     // so try to stop the sketch.
-    try { noLoop(); } catch (e) {}
+    try { global.noLoop(); } catch (e) {}
 
     errorCb(message, line);
   });
@@ -74,3 +75,5 @@ function startSketch(sketch, p5version, maxRunTime, loopCheckFuncName,
 
   loadP5(p5version);
 }
+
+global.startSketch = startSketch;

--- a/lib/preview-frame.ts
+++ b/lib/preview-frame.ts
@@ -5,13 +5,13 @@ declare interface PreviewFrameWindow extends PreviewFrame {
   noLoop: () => void;
 }
 
-var global = window as PreviewFrameWindow;
+let global = window as PreviewFrameWindow;
 
 function loadP5(version: string, cb?: () => void) {
-  var url = '//cdnjs.cloudflare.com/ajax/libs/p5.js/' + version + '/p5.js';
-  var script = document.createElement('script');
+  let url = '//cdnjs.cloudflare.com/ajax/libs/p5.js/' + version + '/p5.js';
+  let script = document.createElement('script');
 
-  cb = cb || function() {};
+  cb = cb || (() => {});
 
   script.onload = cb;
   script.setAttribute('src', url);
@@ -20,13 +20,13 @@ function loadP5(version: string, cb?: () => void) {
 }
 
 function LoopChecker(sketch: string, funcName: string, maxRunTime: number) {
-  var self = {
+  let self = {
     wasTriggered: false,
     getLineNumber() {
-      var index = loopCheckFailureRange[0];
-      var line = 1;
+      let index = loopCheckFailureRange[0];
+      let line = 1;
 
-      for (var i = 0; i < index; i++) {
+      for (let i = 0; i < index; i++) {
         if (sketch[i] === '\n')
           line++;
       }
@@ -34,10 +34,10 @@ function LoopChecker(sketch: string, funcName: string, maxRunTime: number) {
       return line;
     }
   };
-  var startTime = Date.now();
-  var loopCheckFailureRange = null;
+  let startTime = Date.now();
+  let loopCheckFailureRange: Array<number> = null;
 
-  global[funcName] = function(range) {
+  global[funcName] = (range: Array<number>) => {
     if (Date.now() - startTime > maxRunTime) {
       self.wasTriggered = true;
       loopCheckFailureRange = range;
@@ -45,7 +45,7 @@ function LoopChecker(sketch: string, funcName: string, maxRunTime: number) {
     }
   };
 
-  setInterval(function() {
+  setInterval(() => {
     startTime = Date.now();
   }, maxRunTime / 2);
 
@@ -55,14 +55,14 @@ function LoopChecker(sketch: string, funcName: string, maxRunTime: number) {
 function startSketch(sketch: string, p5version: string, maxRunTime: number,
                      loopCheckFuncName: string,
                      errorCb: PreviewFrameErrorReporter) {
-  var sketchScript = document.createElement('script');
-  var loopChecker = LoopChecker(sketch, loopCheckFuncName, maxRunTime);
+  let sketchScript = document.createElement('script');
+  let loopChecker = LoopChecker(sketch, loopCheckFuncName, maxRunTime);
 
   sketchScript.textContent = sketch;
 
-  global.addEventListener('error', function(e: ErrorEvent) {
-    var message = e.message;
-    var line = undefined;
+  global.addEventListener('error', (e: ErrorEvent) => {
+    let message = e.message;
+    let line = undefined;
 
     if (loopChecker.wasTriggered) {
       message = "Your loop is taking too long to run.";

--- a/lib/preview.tsx
+++ b/lib/preview.tsx
@@ -6,27 +6,15 @@ import LoopInserter from "./loop-inserter";
 
 const LOOP_CHECK_FUNC_NAME = '__loopCheck';
 
-interface ErrorReporter {
-  (message: string, line?: number): any
-}
-
 interface Props {
   width: number,
   content: string,
   timestamp: number,
-  onError: ErrorReporter
+  onError: PreviewFrameErrorReporter
 }
 
 interface State {
 
-}
-
-// Eventualy we might want the preview frame to exist on a separate
-// origin for security, which means that we'd have to use postMessage()
-// to communicate with it. Thus this interface needs to be asynchronous.
-interface PreviewFrameProxy extends Window {
-  startSketch: (sketch: string, p5version: string, maxRunTime: number,
-                loopCheckFuncName: string, errorCb: ErrorReporter) => any
 }
 
 export default class Preview extends React.Component<Props, State> {

--- a/lib/preview.tsx
+++ b/lib/preview.tsx
@@ -46,7 +46,7 @@ export default class Preview extends React.Component<Props, State> {
       // Note that this should never be called if we're already unmounted,
       // since that means the iframe will have been removed from the DOM,
       // in which case it shouldn't be emitting events anymore.
-      let frame = iframe.contentWindow as PreviewFrameProxy;
+      let frame = iframe.contentWindow as PreviewFrame;
       frame.startSketch(content, '0.4.23', 1000,
                         LOOP_CHECK_FUNC_NAME, this.props.onError);
     });

--- a/preview-frame.html
+++ b/preview-frame.html
@@ -22,5 +22,5 @@ body {
 </style>
 <title>Preview</title>
 <body>
-  <script src="static/preview-frame.js"></script>
+  <script src="preview-frame.bundle.js"></script>
 </body>

--- a/preview-frame.html
+++ b/preview-frame.html
@@ -1,25 +1,5 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
-<style>
-html, body {
-  height: 100%;
-}
-
-body {
-  margin: 0;
-  display: -webkit-box;  /* OLD - iOS 6-, Safari 3.1-6, BB7 */
-  display: -webkit-flex; /* NEW - Safari 6.1+. iOS 7.1+, BB10 */
-  display: flex;
-
-  /* This centers our sketch horizontally. */
-  -webkit-justify-content: center;
-  justify-content: center;
-
-  /* This centers our sketch vertically. */
-  -webkit-align-items: center;
-  align-items: center;
-}
-</style>
 <title>Preview</title>
 <body>
   <script src="preview-frame.bundle.js"></script>

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,6 +13,7 @@
     "typings/chai/chai.d.ts",
     "test/main.tsx",
     "test/test-loop-inserter.tsx",
+    "lib/preview-frame.ts",
     "lib/falafel.ts",
     "lib/main.tsx",
     "lib/app.tsx",

--- a/typings/custom.d.ts
+++ b/typings/custom.d.ts
@@ -11,3 +11,25 @@ declare namespace Url {
 declare module "url" {
     export = Url;
 }
+
+declare interface PreviewFrameErrorReporter {
+  (message: string, line?: number): any
+}
+
+declare interface PreviewFrameStartSketch {
+  (sketch: string, p5version: string, maxRunTime: number,
+   loopCheckFuncName: string, errorCb: PreviewFrameErrorReporter): void
+}
+
+// Eventually we might want the preview frame to exist on a separate
+// origin for security, which means that we'd have to use postMessage()
+// to communicate with it. Thus this interface needs to be asynchronous.
+declare interface PreviewFrameProxy extends Window {
+  startSketch: PreviewFrameStartSketch
+}
+
+declare interface PreviewFrameWindow extends Window {
+  // This is exported by p5 when it's in global mode.
+  noLoop: () => void;
+  startSketch: PreviewFrameStartSketch;
+}

--- a/typings/custom.d.ts
+++ b/typings/custom.d.ts
@@ -16,20 +16,11 @@ declare interface PreviewFrameErrorReporter {
   (message: string, line?: number): any
 }
 
-declare interface PreviewFrameStartSketch {
-  (sketch: string, p5version: string, maxRunTime: number,
-   loopCheckFuncName: string, errorCb: PreviewFrameErrorReporter): void
-}
-
 // Eventually we might want the preview frame to exist on a separate
 // origin for security, which means that we'd have to use postMessage()
 // to communicate with it. Thus this interface needs to be asynchronous.
-declare interface PreviewFrameProxy extends Window {
-  startSketch: PreviewFrameStartSketch
-}
-
-declare interface PreviewFrameWindow extends Window {
-  // This is exported by p5 when it's in global mode.
-  noLoop: () => void;
-  startSketch: PreviewFrameStartSketch;
+declare interface PreviewFrame extends Window {
+  startSketch: (sketch: string, p5version: string, maxRunTime: number,
+                loopCheckFuncName: string,
+                errorCb: PreviewFrameErrorReporter) => void
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,7 +1,8 @@
 module.exports = {
   entry: {
-    main: './lib/main.tsx',
-    tests: './test/main.tsx'
+    'main': './lib/main.tsx',
+    'preview-frame': './lib/preview-frame.ts',
+    'tests': './test/main.tsx'
   },
   output: {
     filename: '[name].bundle.js'


### PR DESCRIPTION
Since it's part of the widget, its logic isn't particularly trivial, and it shares interfaces that its parent frame calls into, it'd be nice if this were TypeScript too.

Since this means tying the code into webpack, it will also allow us to use PostCSS on the frame's CSS, so we won't need to manually vendor-prefix anything anymore.