### PR TITLE
Implement autosave w/ sessionStorage.

### DIFF
--- a/lib/app.tsx
+++ b/lib/app.tsx
@@ -4,6 +4,7 @@ import PureComponent from "./pure-component";
 import Toolbar from "./toolbar";
 import Editor from "./editor";
 import Preview from "./preview";
+import { Autosaver } from "./autosaver";
 
 interface ErrorMessage {
   message: string,
@@ -14,6 +15,7 @@ interface AppProps {
   initialContent: string,
   previewWidth: number,
   p5version: string,
+  autosaver?: Autosaver,
   autoplay?: boolean
 }
 
@@ -51,7 +53,11 @@ export default class App extends PureComponent<AppProps, AppState> {
   }
 
   componentDidMount() {
-    if (this.props.autoplay) {
+    let autosave = this.props.autosaver && this.props.autosaver.restore();
+
+    if (autosave && autosave !== this.state.editorContent) {
+      this.setState({ editorContent: autosave });
+    } else if (this.props.autoplay) {
       this.handlePlayClick();
     }
   }
@@ -63,6 +69,7 @@ export default class App extends PureComponent<AppProps, AppState> {
       canUndo: canUndo,
       canRedo: canRedo
     });
+    this.props.autosaver.save(newValue);
   }
 
   handlePreviewError = (message: string, line?: number) => {

--- a/lib/autosaver.ts
+++ b/lib/autosaver.ts
@@ -1,0 +1,29 @@
+export interface Autosaver {
+  restore(): string,
+  save(value: string): void
+}
+
+export class SessionStorageAutosaver implements Autosaver {
+  id: string
+
+  constructor(id: string) {
+    this.id = id;
+  }
+
+  save(value: string) {
+    try {
+      window.sessionStorage[this.id] = value;
+    } catch (e) {
+      // It's likely that we ran out of storage space or are in
+      // private browsing mode or something. Regardless, autosave is
+      // a parachute, so it's regrettable but ultimately not
+      // catastrophic for us to fail here.
+
+      console.log("Autosave for " + this.id + " failed", e);
+    }
+  }
+
+  restore(): string {
+    return window.sessionStorage[this.id];
+  }
+}

--- a/lib/main.tsx
+++ b/lib/main.tsx
@@ -4,6 +4,7 @@ import ReactDOM = require("react-dom");
 import url = require("url");
 
 import * as defaults from "./defaults";
+import { SessionStorageAutosaver } from "./autosaver";
 import App from "./app";
 
 let defaultSketchJS = require("raw!./default-sketch.js") as string;
@@ -12,6 +13,7 @@ require("../css/style.css");
 
 function start() {
   let qs = url.parse(window.location.search, true).query;
+  let id = document.referrer + '_' + qs['id'];
   let autoplay = (qs['autoplay'] === 'on');
   let initialContent = qs['sketch'] || defaultSketchJS;
   let p5version = qs['p5version'] || defaults.P5_VERSION;
@@ -25,6 +27,7 @@ function start() {
 
   ReactDOM.render(
     <App initialContent={initialContent}
+         autosaver={new SessionStorageAutosaver(id)}
          p5version={p5version}
          previewWidth={previewWidth}
          autoplay={autoplay} />,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,6 +17,7 @@
     "test/test-implicit-sketch.tsx",
     "lib/pure-component.tsx",
     "lib/defaults.ts",
+    "lib/autosaver.ts",
     "lib/p5-widget.ts",
     "lib/preview-frame.ts",
     "lib/falafel.ts",


### PR DESCRIPTION
This fixes #40 by storing the current code (whenever it changes) in [`sessionStorage`](https://developer.mozilla.org/en-US/docs/Web/API/Window/sessionStorage) and bringing it back on re-instantiation. The new code is added to the CodeMirror widget's history stack to make undo/revert easy.

Also, this change requires each widget on a page to have a unique identifier, so that each widget can have its own unique `sessionStorage` key. This identifier is created by combining the [`document.referrer`](https://developer.mozilla.org/en-US/docs/Web/API/Document/referrer) of the widget (i.e., the URL of the embedding page) with a number based on the position of the widget in the embedding page's DOM.
