### PR TITLE
Add foundational support for loading p5 addons in preview-frame.ts.

### DIFF
--- a/lib/preview-frame.ts
+++ b/lib/preview-frame.ts
@@ -20,6 +20,9 @@ function loadScript(url, cb?: () => void) {
   cb = cb || (() => {});
 
   script.onload = cb;
+  script.onerror = () => {
+    console.log("Failed to load script: " + url);
+  };
   script.setAttribute('src', url);
 
   document.body.appendChild(script);


### PR DESCRIPTION
This adds foundational support for loading multiple libraries which depend on p5.js in `preview-frame.ts`.  It effectively implements option 3 described in https://github.com/toolness/p5.js-widget/issues/53#issuecomment-240387563.

The biggest volatility here is that it uses an undocumented feature of the `p5` constructor whereby if a `sketch` function isn't passed in as the first argument, p5 will initialize itself in global mode.  If we can make this a documented, supported use case in p5 core, that will ensure the widget continues to work as p5 matures. I've filed https://github.com/processing/p5.js/issues/1570 for this.

Thoughts @kaganjd ?